### PR TITLE
Expand FAQ (academic citation, derivative works, model card)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -99,3 +99,15 @@ Not at present. The OpenMDW License Agreement, version 1.0, has just been announ
 In the meantime, users of [SPDX short-form identifiers](https://spdx.org/ids) can use the standard `LicenseRef-` format that SPDX provides for any licenses that are not on the SPDX License List, in a manner such as the following:
 
 `SPDX-License-Identifier: LicenseRef-OpenMDW-1.0`
+
+## 13.  How should researchers reference or cite models released under OpenMDW-1.0?
+
+OpenMDW-1.0 does not impose citation. Model contributors may include a CITATION.cff file or citation instructions in the README file.
+
+## 14. What are the expectations for licensing derivative works?
+
+OpenMDW-1.0 is a permissive license, meaning that if you create a derivative work (such as a fine-tuned model using this license), you may choose to distribute it under OpenMDW-1.0 or under a different license of your choice.
+
+## 15. How should OpenMDW-1.0 be referenced in model cards?
+
+Model cards are short documents accompanying trained machine learning models that provide benchmarked evaluation in a variety of conditions. To reference OpenMDW-1.0, it is recommended to set the License field in the model card metadata and link to the full license text of this repository. You can also include a short explanation in the usage or limitations section of the model card if it exists.

--- a/FAQ.md
+++ b/FAQ.md
@@ -106,7 +106,7 @@ OpenMDW-1.0 does not impose citation. Model contributors may include a CITATION.
 
 ## 14. What are the expectations for licensing derivative works?
 
-OpenMDW-1.0 is a permissive license, meaning that if you create a derivative work (such as a fine-tuned model using this license), you may choose to distribute it under OpenMDW-1.0 or under a different license of your choice.
+OpenMDW-1.0 is a permissive license, meaning that if you create a derivative work (such as a fine-tuned model using this license), you have to preserve the original license.
 
 ## 15. How should OpenMDW-1.0 be referenced in model cards?
 


### PR DESCRIPTION
This PR adds three new FAQ entries (Q13–Q15) to address a few questions raised by academia and industry OSPOs. Changes introduced include:

- Q13: guidance on how researchers can reference or cite models released under OpenMDW-1.0
- Q14: expectations and recommendations for licensing fine-tuned or modified models.
- Q15: Instructions for referencing OpenMDW-1.0 in model cards

Motivation:

- Help adoption in academic and open research contexts
- Provide advice for researchers publishing models with model cards